### PR TITLE
Make the bot code standalone to make it easier to try out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*__pycache__
+ancient_adventure.db
+secret.txt

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We wanted to create a unique project that allowed us to pool our collective know
 Our project is a Discord bot based Text Adventure game. The player will have a thrilling story about escaping an unknown building they have been thrust into.
 
 ## How to use it
-Coming soon to a Discord server near you...
+Create an application in the Discord Developer portal, create a bot, add it to a server, and then copy the bot token into a file called secret.txt in the same directory as main.py. Run main.py.
 
 ## How we built it
 Our project is built upon python, we utilize the discord.py library to create the bot features. We are utilizing a Linode Cloud VM to host our CockroachDB Database with a Domain.com Domain for easy access, a Google Cloud Linux VM is hosting our project/hackathon website utilizing a GoDaddy Registry domain, and Replit to host our code base and was what enabled us to easily collaborate.

--- a/cogs/game.py
+++ b/cogs/game.py
@@ -9,10 +9,10 @@ from utils import sleeping
 items = ['knife', 'sword', 'shield', 'invisibility potion']
 user_items = []
 
-
 class Game(commands.Cog):
     def __init__(self, client):
         self.client = client  # this allows us to access the client within our cog
+        db.createDatabase()
         self.conn = db.connectToDatabase()
 
     @commands.command()

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from threading import Thread
 
 def bot():
     # Prefix for my commands
-    client = commands.Bot(command_prefix="@", help_command=None)
+    client = commands.Bot(command_prefix=">", help_command=None)
 
 
     # Loads our cogs library

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from threading import Thread
 
 def bot():
     # Prefix for my commands
-    client = commands.Bot(command_prefix=">", help_command=None)
+    client = commands.Bot(command_prefix="@", help_command=None)
 
 
     # Loads our cogs library
@@ -57,7 +57,10 @@ def bot():
         if filename.endswith(".py"):
             client.load_extension(f"cogs.{filename[:-3]}")
 
-    client.run(os.environ['bot_token'])
+    # Read in the bot token from the file secret.txt and then run it
+    with open('secret.txt', 'r') as file:
+        bot_token = file.read()
+    client.run(bot_token)
 
 if __name__ == '__main__':
     # Thread(target=main()).start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ idna>=3.2
 multidict>=5.1.0
 yarl>=1.6.3
 chardet>=4.0.0
-psycopg2>=2.9.1
+db-sqlite3>=0.0.1
 setuptools>=57.0.0


### PR DESCRIPTION
I've re-written the database code to use a sqlite database in the local directory to increase portability. I've also changed the mechanism for loading the Discord bot token from an environment variable to loading it from a secret.txt file.